### PR TITLE
Fix warnings display after login

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -128,7 +128,8 @@ app.post('/login', async (req, res) => {
 
     res.json({
       message: `Usuario ${user.email} logueado correctamente`,
-      token
+      token,
+      userId: user.id
     });
   } catch (error) {
     console.error('Error en /login:', error);

--- a/frontend/loginJS.js
+++ b/frontend/loginJS.js
@@ -21,13 +21,16 @@
     if (response.ok) {
       alert(data.message);
 
-      if (loginType === 'admin') {
-        localStorage.setItem('adminToken', data.token);
-        window.location.href = '/frontend/home.html';
-      } else {
-        localStorage.setItem('token', data.token);
-        window.location.href = '/frontend/home.html';
-      }
+        if (loginType === 'admin') {
+          localStorage.setItem('adminToken', data.token);
+          window.location.href = '/frontend/home.html';
+        } else {
+          localStorage.setItem('token', data.token);
+          if (data.userId) {
+            localStorage.setItem('userId', data.userId);
+          }
+          window.location.href = '/frontend/home.html';
+        }
     } else {
       alert(data.error || 'Error al iniciar sesión');
     }

--- a/frontend/warnings.html
+++ b/frontend/warnings.html
@@ -62,7 +62,7 @@
   </div>
 
   <script>
-    const token = localStorage.getItem('userToken'); // cambia esto según cómo almacenes el token
+    const token = localStorage.getItem('token');
     const userId = localStorage.getItem('userId');   // asegúrate de tener el ID guardado
 
     async function fetchWarnings() {


### PR DESCRIPTION
## Summary
- return user ID when logging in
- store user ID in browser on successful login
- use existing token key in warnings page to fetch warnings

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6844d98602a083228b8a85a0ceb8eda1