### PR TITLE
Fix provider details view

### DIFF
--- a/backend/src/routes/productRoutes.js
+++ b/backend/src/routes/productRoutes.js
@@ -75,7 +75,7 @@ router.get('/', async (req, res) => {
       include: [{
         model: User,
         as: 'provider',
-        attributes: ['name']
+        attributes: ['id', 'name']
       }],
       order: [['id', 'DESC']],
     });

--- a/backend/src/routes/userRoutes.js
+++ b/backend/src/routes/userRoutes.js
@@ -42,7 +42,7 @@ router.post('/:id/photo', authenticateToken, upload.single('photo'), async (req,
 router.get('/seeProviders/:id', async (req, res) => {
   try {
     const provider = await User.findByPk(req.params.id, {
-      attributes: ['id', 'name', 'email', 'phone', 'description', 'imageUrl', 'rol'],
+      attributes: ['id', 'name', 'email', 'location', 'description', 'imageUrl', 'rol'],
     });
 
     if (!provider || provider.rol !== 'proveedor') {
@@ -56,7 +56,5 @@ router.get('/seeProviders/:id', async (req, res) => {
     res.status(500).json({ error: 'Error interno' });
   }
 });
-
-module.exports = router;
 
 module.exports = router;

--- a/frontend/seeProvider.html
+++ b/frontend/seeProvider.html
@@ -30,15 +30,17 @@
 
       try {
         // Cargar proveedor
-        const providerRes = await fetch(`http://localhost:3000/api/seeProviders/${providerId}`);
+        const providerRes = await fetch(`http://localhost:3000/api/users/seeProviders/${providerId}`);
         if (!providerRes.ok) throw new Error('No se pudo cargar el proveedor');
         const provider = await providerRes.json();
 
         document.getElementById('providerInfo').innerHTML = `
-          <h3>${provider.name}</h3>
-          <p><strong>Email:</strong> ${provider.email}</p>
-          <p><strong>Phone:</strong> ${provider.phone || 'No info'}</p>
-          <p><strong>Description:</strong> ${provider.description || 'No description'}</p>
+          <div class="text-center">
+            <img src="${provider.imageUrl || '#'}" alt="Provider Image" class="img-fluid rounded-circle mb-3" style="max-width: 150px;">
+            <h3>${provider.name}</h3>
+            <p><strong>Location:</strong> ${provider.location || 'No info'}</p>
+            <p><strong>Description:</strong> ${provider.description || 'No description'}</p>
+          </div>
         `;
 
         // Cargar productos del proveedor


### PR DESCRIPTION
## Summary
- show provider location, description, and photo
- adjust fetch URL for provider details
- include provider id in products endpoint
- return provider location from backend
- clean duplicate export in routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684504b49ecc832284737327847e8d94