### PR TITLE
Fix provider image path

### DIFF
--- a/frontend/seeProvider.html
+++ b/frontend/seeProvider.html
@@ -35,7 +35,12 @@
         const provider = await providerRes.json();
 
         // Generar URL segura para la imagen
-        const imageUrl = provider.imageUrl || 'https://via.placeholder.com/150';
+        let imageUrl = 'https://via.placeholder.com/150';
+        if (provider.imageUrl) {
+          imageUrl = provider.imageUrl.startsWith('http')
+            ? provider.imageUrl
+            : `http://localhost:3000/uploads/${provider.imageUrl}`;
+        }
 
         document.getElementById('providerInfo').innerHTML = `
           <div class="text-center">


### PR DESCRIPTION
## Summary
- adjust provider image path handling in **seeProvider** page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68450f5295e88322a3c0df5ef280b599