### PR TITLE
Fix timestamps and stats

### DIFF
--- a/backend/src/controllers/statsController.js
+++ b/backend/src/controllers/statsController.js
@@ -1,30 +1,55 @@
 const User = require('../models/userModel');
 const Product = require('../models/productModel');
+const Warning = require('../models/warningModel');
 const sequelize = require('../config/database');
 
 exports.getGrowthStats = async (req, res) => {
   try {
+    const totalUsers = await User.count();
+    const totalProducts = await Product.count();
+    const totalWarnings = await Warning.count();
+
+    const usersByRole = await User.findAll({
+      attributes: ['rol', [sequelize.fn('COUNT', sequelize.col('rol')), 'count']],
+      group: ['rol']
+    });
+
+    const productsPerUser = await Product.findAll({
+      attributes: ['userId', [sequelize.fn('COUNT', sequelize.col('id')), 'count']],
+      group: ['userId']
+    });
+
+    const allWarnings = await Warning.findAll({ attributes: ['createdAt'] });
+
     const userStats = await User.findAll({
       attributes: [
-        [sequelize.literal("TO_CHAR(\"createdAt\", 'YYYY-MM')"), 'month'],
+        [sequelize.literal('TO_CHAR("createdat", \'YYYY-MM\')'), 'month'],
         [sequelize.fn('COUNT', '*'), 'count']
       ],
-      group: [sequelize.literal("TO_CHAR(\"createdAt\", 'YYYY-MM')")],
-      order: [[sequelize.literal("TO_CHAR(\"createdAt\", 'YYYY-MM')"), 'ASC']]
+      group: [sequelize.literal('TO_CHAR("createdat", \'YYYY-MM\')')],
+      order: [[sequelize.literal('TO_CHAR("createdat", \'YYYY-MM\')'), 'ASC']]
     });
 
     const productStats = await Product.findAll({
       attributes: [
-        [sequelize.literal("TO_CHAR(\"createdAt\", 'YYYY-MM')"), 'month'],
+        [sequelize.literal('TO_CHAR("createdat", \'YYYY-MM\')'), 'month'],
         [sequelize.fn('COUNT', '*'), 'count']
       ],
-      group: [sequelize.literal("TO_CHAR(\"createdAt\", 'YYYY-MM')")],
-      order: [[sequelize.literal("TO_CHAR(\"createdAt\", 'YYYY-MM')"), 'ASC']]
+      group: [sequelize.literal('TO_CHAR("createdat", \'YYYY-MM\')')],
+      order: [[sequelize.literal('TO_CHAR("createdat", \'YYYY-MM\')'), 'ASC']]
     });
 
-    res.json({ users: userStats, products: productStats });
+    res.json({
+      totalUsers,
+      totalProducts,
+      totalWarnings,
+      usersByRole,
+      productsPerUser,
+      allWarnings,
+      growthData: { users: userStats, products: productStats }
+    });
   } catch (error) {
     console.error(error);
-    res.status(500).json({ error: 'Error fetching growth stats' });
+    res.status(500).json({ error: 'Error fetching statistics' });
   }
 };

--- a/backend/src/models/adminModel.js
+++ b/backend/src/models/adminModel.js
@@ -25,7 +25,9 @@ const Admin = sequelize.define('Admin', {
     defaultValue: DataTypes.NOW
   }
 }, {
-  timestamps: false,
+  timestamps: true,
+  createdAt: 'createdat',
+  updatedAt: 'updatedat',
   tableName: 'admins'
 });
 

--- a/backend/src/models/productModel.js
+++ b/backend/src/models/productModel.js
@@ -21,6 +21,8 @@ const Product = sequelize.define('Product', {
   }
 }, {
   timestamps: true,
+  createdAt: 'createdat',
+  updatedAt: 'updatedat',
   tableName: 'products'
 });
 

--- a/backend/src/models/userModel.js
+++ b/backend/src/models/userModel.js
@@ -41,14 +41,11 @@ const User = sequelize.define('User', {
     field: 'imageurl', // nombre de la columna en la base de datos
     allowNull: true
   },
-  created_at: {
-    type: DataTypes.DATE,
-    defaultValue: DataTypes.NOW,
-    allowNull: false,
-  },
 
 }, {
   timestamps: true,
+  createdAt: 'createdat',
+  updatedAt: 'updatedat',
   tableName: 'users'
 });
 

--- a/backend/src/routes/profileRoutes.js
+++ b/backend/src/routes/profileRoutes.js
@@ -24,7 +24,7 @@ router.get('/profile', authenticateToken, async (req, res) => {
       description: user.description,
       imageUrl: user.imageUrl,  // acá se debe llamar imageUrl para ser consistente
       rol: user.rol,
-      createdAt: user.created_at,
+      createdAt: user.createdAt,
     });
   } catch (error) {
     res.status(500).json({ message: 'Error interno' });


### PR DESCRIPTION
## Summary
- standardize timestamp column names for Sequelize models
- update admin/user/product stats endpoint
- fix profile route to use camelCase timestamps

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6845bf27fbc8832285446426e247df11